### PR TITLE
Increase staked low risk cost from 1% to 4%

### DIFF
--- a/src/quote-engine.js
+++ b/src/quote-engine.js
@@ -386,7 +386,7 @@ class QuoteEngine {
     const STAKED_HIGH_RISK_COST = Decimal(100);
     const LOW_RISK_COST_LIMIT_NXM = Decimal(100000).mul('1e18');
     const PRICING_EXPONENT = Decimal(7);
-    const STAKED_LOW_RISK_COST = Decimal(1);
+    const STAKED_LOW_RISK_COST = Decimal(4);
     // uncappedRiskCost = stakedHighRiskCost * [1 - netStakedNXM/lowRiskCostLimit ^ (1/pricingExponent) ];
     const exponent = Decimal(1).div(PRICING_EXPONENT);
     const uncappedRiskCost = STAKED_HIGH_RISK_COST


### PR DESCRIPTION
This PR implements proposal 92.

As per forum discussions increase staked_risk_cost_low from 1% to 4%. This will increase minimum price from 1.3% to 5.2%