### PR TITLE
fix displayed net staked NXM vs actual adjusted value

### DIFF
--- a/src/quote-engine.js
+++ b/src/quote-engine.js
@@ -110,7 +110,7 @@ class QuoteEngine {
   }
 
   /**
-   * Fetches total net staked NXM on a smart contract at timestamp 'now'
+   * Fetches total pending unstakes for a contract
    *
    * @param {string} contractAddress
    * @return {Decimal} Net Staked NXM amount as decimal.js instance

--- a/src/quote-engine.js
+++ b/src/quote-engine.js
@@ -110,7 +110,7 @@ class QuoteEngine {
   }
 
   /**
-   * Fetches total pending unstakes for a contract
+   * Fetches total unprocessed unstakes for a contract
    *
    * @param {string} contractAddress
    * @return {Decimal} Net Staked NXM amount as decimal.js instance


### PR DESCRIPTION
The actual displayed net staked NXM is different from the underlying adjusted value used in the quote calculation (that one has the total unprocessed unstakes divided by 2). fix this issue