### PR TITLE
Feature/in memory active cover tracking

### DIFF
--- a/scripts/active-cover-processing.js
+++ b/scripts/active-cover-processing.js
@@ -1,0 +1,171 @@
+const fetch = require('node-fetch');
+const log = require("../src/log");
+const Web3 = require("web3");
+const NexusContractLoader = require("../src/nexus-contract-loader");
+const {getEnv} = require("../src/utils");
+const BN = require('bn.js');
+const Decimal = require('decimal.js');
+
+const CoverAmountTracker = require('../src/cover-amount-tracker');
+const CONTRACTS_URL = 'https://api.nexusmutual.io/coverables/contracts.json';
+const hex = string => '0x' + Buffer.from(string).toString('hex');
+
+function createBatches (a, batchSize) {
+    const batches = [];
+    let currentBatch = [];
+    for (let i = 0; i < a.length; i++) {
+        if (currentBatch.length === batchSize) {
+            batches.push(currentBatch);
+            currentBatch = [a[i]];
+        } else {
+            currentBatch.push(a[i]);
+        }
+    }
+    if (currentBatch.length > 0) {
+        batches.push(currentBatch);
+    }
+    return batches;
+}
+
+
+async function fetchAllActiveCovers ({ gateway, tokenController }) {
+    const url = 'https://nexustracker.io/all_covers';
+    const covers = await fetch(url, { headers: { 'Content-Type': 'application/json' } }).then(x => x.json());
+
+
+    const now = new Date().getTime();
+    let j = 0;
+    for (let i = 0; i < covers.length; i++) {
+        const cover = covers[i];
+
+        if (new Date(cover.end_time).getTime() > now) {
+            j++;
+        }
+
+        if (j > 4) {
+            break;
+        }
+    }
+
+    const active = covers.filter(c => new Date(c.end_time).getTime() > now);
+    console.log({
+        activeCount: active.length
+    })
+    const activeCoverIds = active.map(c => c.cover_id);
+
+    const coverData = [];
+    for (const batch of createBatches(activeCoverIds, 50)) {
+        const coversInBatch = await Promise.all(batch.map(async id => {
+            const coverData = await gateway.getCover(id);
+            const coverInfo = await tokenController.coverInfo(id);
+            return { ...coverData, ...coverInfo };
+        }));
+        coverData.push(coversInBatch);
+    }
+    return coverData;
+}
+
+
+async function main() {
+    require('dotenv').config();
+
+    const PROVIDER_URL = getEnv('PROVIDER_URL');
+    const VERSION_DATA_URL = getEnv('VERSION_DATA_URL');
+    const PRIVATE_KEY = getEnv('PRIVATE_KEY');
+    const NETWORK = getEnv('NETWORK', 'mainnet');
+    const MONGO_URL = getEnv('MONGO_URL', 'mainnet');
+    const CAPACITY_FACTOR_END_DATE = getEnv('CAPACITY_FACTOR_END_DATE', 'mainnet');
+    const QUOTE_SIGN_MIN_INTERVAL_SECONDS = parseInt(getEnv('QUOTE_SIGN_MIN_INTERVAL_SECONDS'));
+
+    log.info(JSON.stringify({
+        VERSION_DATA_URL,
+        NETWORK,
+        CAPACITY_FACTOR_END_DATE,
+        QUOTE_SIGN_MIN_INTERVAL_SECONDS,
+    }));
+
+    log.info(`Connecting to node at ${new URL(PROVIDER_URL).origin}..`);
+    const web3 = new Web3(PROVIDER_URL);
+    await web3.eth.net.isListening();
+    
+
+    log.info('Initializing NexusContractLoader..');
+    const nexusContractLoader = new NexusContractLoader(NETWORK, VERSION_DATA_URL, web3.eth.currentProvider);
+    await nexusContractLoader.init();
+
+
+    const coverAmountTracker = new CoverAmountTracker(nexusContractLoader, web3);
+
+    await coverAmountTracker.initialize();
+    const active = await coverAmountTracker.getActiveCoverAmount(
+        '0x1F98431c8aD98523631AE4a59f267346ea31F984',
+        'ETH'
+    );
+    console.log({
+        active: active.toString()
+    })
+
+    const quotationData = nexusContractLoader.instance('QD');
+
+    const products = await fetch(CONTRACTS_URL).then(r => r.json());
+
+    const significantDeltas = [];
+
+    const batches = createBatches(Object.keys(products), 50);
+
+    for (const batch of batches) {
+        await Promise.all(batch.map(async productKey => {
+
+            const product = products[productKey];
+            if (product.deprecated) {
+                return;
+            }
+
+            for (const asset of ['ETH', 'DAI']) {
+                const trackerActiveCoverAmount = await coverAmountTracker.getActiveCoverAmount(
+                    productKey,
+                    asset
+                );
+
+                const onchainActiveCoverAmount = (await quotationData.getTotalSumAssuredSC(productKey, hex(asset)))
+                    .mul(new BN(1e18.toString()));
+
+
+                const activeCoverAmountDelta = trackerActiveCoverAmount.sub(onchainActiveCoverAmount).abs();
+
+                const counts = {
+                    trackerActiveCoverAmount: Decimal(trackerActiveCoverAmount.toString()).div(1e18),
+                    onchainActiveCoverAmount: Decimal(onchainActiveCoverAmount.toString()).div(1e18),
+                    activeCoverAmountDelta: Decimal(activeCoverAmountDelta.toString()).div(1e18)
+                };
+                // console.log(counts);
+
+                if (activeCoverAmountDelta.gt(new BN(1e18.toString()))) {
+                    significantDeltas.push({...counts, productName: product.name, productKey, asset });
+                    // console.log(`Significant different for ${product.name} ${productKey}`);
+                }
+            }
+        }));
+    }
+    console.log(significantDeltas);
+
+    return;
+
+    const allActiveCovers = await fetchAllActiveCovers({
+            gateway: nexusContractLoader.instance('GW'),
+            tokenController: nexusContractLoader.instance('TC')
+    });
+
+    console.log(allActiveCovers);
+}
+
+
+if (require.main === module) {
+    main()
+        .then(() => console.log('Done!'))
+        .catch(e => {
+            console.log('Unhandled error encountered: ', e.stack);
+            process.exit(1);
+        });
+}
+

--- a/scripts/active-cover-processing.js
+++ b/scripts/active-cover-processing.js
@@ -1,8 +1,8 @@
 const fetch = require('node-fetch');
-const log = require("../src/log");
-const Web3 = require("web3");
-const NexusContractLoader = require("../src/nexus-contract-loader");
-const {getEnv} = require("../src/utils");
+const log = require('../src/log');
+const Web3 = require('web3');
+const NexusContractLoader = require('../src/nexus-contract-loader');
+const { getEnv } = require('../src/utils');
 const BN = require('bn.js');
 const Decimal = require('decimal.js');
 
@@ -11,161 +11,154 @@ const CONTRACTS_URL = 'https://api.nexusmutual.io/coverables/contracts.json';
 const hex = string => '0x' + Buffer.from(string).toString('hex');
 
 function createBatches (a, batchSize) {
-    const batches = [];
-    let currentBatch = [];
-    for (let i = 0; i < a.length; i++) {
-        if (currentBatch.length === batchSize) {
-            batches.push(currentBatch);
-            currentBatch = [a[i]];
-        } else {
-            currentBatch.push(a[i]);
-        }
+  const batches = [];
+  let currentBatch = [];
+  for (let i = 0; i < a.length; i++) {
+    if (currentBatch.length === batchSize) {
+      batches.push(currentBatch);
+      currentBatch = [a[i]];
+    } else {
+      currentBatch.push(a[i]);
     }
-    if (currentBatch.length > 0) {
-        batches.push(currentBatch);
-    }
-    return batches;
+  }
+  if (currentBatch.length > 0) {
+    batches.push(currentBatch);
+  }
+  return batches;
 }
-
 
 async function fetchAllActiveCovers ({ gateway, tokenController }) {
-    const url = 'https://nexustracker.io/all_covers';
-    const covers = await fetch(url, { headers: { 'Content-Type': 'application/json' } }).then(x => x.json());
+  const url = 'https://nexustracker.io/all_covers';
+  const covers = await fetch(url, { headers: { 'Content-Type': 'application/json' } }).then(x => x.json());
 
+  const now = new Date().getTime();
+  let j = 0;
+  for (let i = 0; i < covers.length; i++) {
+    const cover = covers[i];
 
-    const now = new Date().getTime();
-    let j = 0;
-    for (let i = 0; i < covers.length; i++) {
-        const cover = covers[i];
-
-        if (new Date(cover.end_time).getTime() > now) {
-            j++;
-        }
-
-        if (j > 4) {
-            break;
-        }
+    if (new Date(cover.end_time).getTime() > now) {
+      j++;
     }
 
-    const active = covers.filter(c => new Date(c.end_time).getTime() > now);
-    console.log({
-        activeCount: active.length
-    })
-    const activeCoverIds = active.map(c => c.cover_id);
-
-    const coverData = [];
-    for (const batch of createBatches(activeCoverIds, 50)) {
-        const coversInBatch = await Promise.all(batch.map(async id => {
-            const coverData = await gateway.getCover(id);
-            const coverInfo = await tokenController.coverInfo(id);
-            return { ...coverData, ...coverInfo };
-        }));
-        coverData.push(coversInBatch);
+    if (j > 4) {
+      break;
     }
-    return coverData;
-}
+  }
 
+  const active = covers.filter(c => new Date(c.end_time).getTime() > now);
+  console.log({
+    activeCount: active.length,
+  });
+  const activeCoverIds = active.map(c => c.cover_id);
 
-async function main() {
-    require('dotenv').config();
-
-    const PROVIDER_URL = getEnv('PROVIDER_URL');
-    const VERSION_DATA_URL = getEnv('VERSION_DATA_URL');
-    const PRIVATE_KEY = getEnv('PRIVATE_KEY');
-    const NETWORK = getEnv('NETWORK', 'mainnet');
-    const MONGO_URL = getEnv('MONGO_URL', 'mainnet');
-    const CAPACITY_FACTOR_END_DATE = getEnv('CAPACITY_FACTOR_END_DATE', 'mainnet');
-    const QUOTE_SIGN_MIN_INTERVAL_SECONDS = parseInt(getEnv('QUOTE_SIGN_MIN_INTERVAL_SECONDS'));
-
-    log.info(JSON.stringify({
-        VERSION_DATA_URL,
-        NETWORK,
-        CAPACITY_FACTOR_END_DATE,
-        QUOTE_SIGN_MIN_INTERVAL_SECONDS,
+  const coverData = [];
+  for (const batch of createBatches(activeCoverIds, 50)) {
+    const coversInBatch = await Promise.all(batch.map(async id => {
+      const coverData = await gateway.getCover(id);
+      const coverInfo = await tokenController.coverInfo(id);
+      return { ...coverData, ...coverInfo };
     }));
-
-    log.info(`Connecting to node at ${new URL(PROVIDER_URL).origin}..`);
-    const web3 = new Web3(PROVIDER_URL);
-    await web3.eth.net.isListening();
-    
-
-    log.info('Initializing NexusContractLoader..');
-    const nexusContractLoader = new NexusContractLoader(NETWORK, VERSION_DATA_URL, web3.eth.currentProvider);
-    await nexusContractLoader.init();
-
-
-    const coverAmountTracker = new CoverAmountTracker(nexusContractLoader, web3);
-
-    await coverAmountTracker.initialize();
-    const active = await coverAmountTracker.getActiveCoverAmount(
-        '0x1F98431c8aD98523631AE4a59f267346ea31F984',
-        'ETH'
-    );
-    console.log({
-        active: active.toString()
-    })
-
-    const quotationData = nexusContractLoader.instance('QD');
-
-    const products = await fetch(CONTRACTS_URL).then(r => r.json());
-
-    const significantDeltas = [];
-
-    const batches = createBatches(Object.keys(products), 50);
-
-    for (const batch of batches) {
-        await Promise.all(batch.map(async productKey => {
-
-            const product = products[productKey];
-            if (product.deprecated) {
-                return;
-            }
-
-            for (const asset of ['ETH', 'DAI']) {
-                const trackerActiveCoverAmount = await coverAmountTracker.getActiveCoverAmount(
-                    productKey,
-                    asset
-                );
-
-                const onchainActiveCoverAmount = (await quotationData.getTotalSumAssuredSC(productKey, hex(asset)))
-                    .mul(new BN(1e18.toString()));
-
-
-                const activeCoverAmountDelta = trackerActiveCoverAmount.sub(onchainActiveCoverAmount).abs();
-
-                const counts = {
-                    trackerActiveCoverAmount: Decimal(trackerActiveCoverAmount.toString()).div(1e18),
-                    onchainActiveCoverAmount: Decimal(onchainActiveCoverAmount.toString()).div(1e18),
-                    activeCoverAmountDelta: Decimal(activeCoverAmountDelta.toString()).div(1e18)
-                };
-                // console.log(counts);
-
-                if (activeCoverAmountDelta.gt(new BN(1e18.toString()))) {
-                    significantDeltas.push({...counts, productName: product.name, productKey, asset });
-                    // console.log(`Significant different for ${product.name} ${productKey}`);
-                }
-            }
-        }));
-    }
-    console.log(significantDeltas);
-
-    return;
-
-    const allActiveCovers = await fetchAllActiveCovers({
-            gateway: nexusContractLoader.instance('GW'),
-            tokenController: nexusContractLoader.instance('TC')
-    });
-
-    console.log(allActiveCovers);
+    coverData.push(coversInBatch);
+  }
+  return coverData;
 }
 
+async function main () {
+  require('dotenv').config();
+
+  const PROVIDER_URL = getEnv('PROVIDER_URL');
+  const VERSION_DATA_URL = getEnv('VERSION_DATA_URL');
+  const NETWORK = getEnv('NETWORK', 'mainnet');
+  const CAPACITY_FACTOR_END_DATE = getEnv('CAPACITY_FACTOR_END_DATE', 'mainnet');
+  const QUOTE_SIGN_MIN_INTERVAL_SECONDS = parseInt(getEnv('QUOTE_SIGN_MIN_INTERVAL_SECONDS'));
+
+  log.info(JSON.stringify({
+    VERSION_DATA_URL,
+    NETWORK,
+    CAPACITY_FACTOR_END_DATE,
+    QUOTE_SIGN_MIN_INTERVAL_SECONDS,
+  }));
+
+  log.info(`Connecting to node at ${new URL(PROVIDER_URL).origin}..`);
+  const web3 = new Web3(PROVIDER_URL);
+  await web3.eth.net.isListening();
+
+  log.info('Initializing NexusContractLoader..');
+  const nexusContractLoader = new NexusContractLoader(NETWORK, VERSION_DATA_URL, web3.eth.currentProvider);
+  await nexusContractLoader.init();
+
+  const coverAmountTracker = new CoverAmountTracker(nexusContractLoader, web3);
+
+  await coverAmountTracker.initialize();
+  const active = await coverAmountTracker.getActiveCoverAmount(
+    '0x1F98431c8aD98523631AE4a59f267346ea31F984',
+    'ETH',
+  );
+  console.log({
+    active: active.toString(),
+  });
+  //
+  // await coverAmountTracker.fetchPayoutEvents();
+  // return;
+
+  const quotationData = nexusContractLoader.instance('QD');
+
+  const products = await fetch(CONTRACTS_URL).then(r => r.json());
+
+  const significantDeltas = [];
+
+  const batches = createBatches(Object.keys(products), 50);
+
+  for (const batch of batches) {
+    await Promise.all(batch.map(async productKey => {
+
+      const product = products[productKey];
+      if (product.deprecated) {
+        return;
+      }
+
+      for (const asset of ['ETH', 'DAI']) {
+        const trackerActiveCoverAmount = await coverAmountTracker.getActiveCoverAmount(
+          productKey,
+          asset,
+        );
+
+        const onchainActiveCoverAmount = (await quotationData.getTotalSumAssuredSC(productKey, hex(asset)))
+          .mul(new BN(1e18.toString()));
+
+        const activeCoverAmountDelta = trackerActiveCoverAmount.sub(onchainActiveCoverAmount).abs();
+
+        const counts = {
+          trackerActiveCoverAmount: Decimal(trackerActiveCoverAmount.toString()).div(1e18),
+          onchainActiveCoverAmount: Decimal(onchainActiveCoverAmount.toString()).div(1e18),
+          activeCoverAmountDelta: Decimal(activeCoverAmountDelta.toString()).div(1e18),
+        };
+        // console.log(counts);
+
+        if (activeCoverAmountDelta.gt(new BN(1e18.toString()))) {
+          significantDeltas.push({ ...counts, productName: product.name, productKey, asset });
+          // console.log(`Significant different for ${product.name} ${productKey}`);
+        }
+      }
+    }));
+  }
+  console.log(significantDeltas);
+  console.log(`Found significant differences in ${significantDeltas.length} protocol/asset pairs`);
+  return;
+
+  const allActiveCovers = await fetchAllActiveCovers({
+    gateway: nexusContractLoader.instance('GW'),
+    tokenController: nexusContractLoader.instance('TC'),
+  });
+
+  console.log(allActiveCovers);
+}
 
 if (require.main === module) {
-    main()
-        .then(() => console.log('Done!'))
-        .catch(e => {
-            console.log('Unhandled error encountered: ', e.stack);
-            process.exit(1);
-        });
+  main()
+    .then(() => console.log('Done!'))
+    .catch(e => {
+      console.log('Unhandled error encountered: ', e.stack);
+      process.exit(1);
+    });
 }
-

--- a/scripts/active-cover-processing.js
+++ b/scripts/active-cover-processing.js
@@ -126,7 +126,9 @@ async function main () {
         const onchainActiveCoverAmount = (await quotationData.getTotalSumAssuredSC(productKey, hex(asset)))
           .mul(new BN(1e18.toString()));
 
-        const activeCoverAmountDelta = trackerActiveCoverAmount.sub(onchainActiveCoverAmount).abs();
+
+        const activeCoverAmountDelta = onchainActiveCoverAmount.sub(trackerActiveCoverAmount);
+
 
         const counts = {
           trackerActiveCoverAmount: Decimal(trackerActiveCoverAmount.toString()).div(1e18),
@@ -135,7 +137,8 @@ async function main () {
         };
         // console.log(counts);
 
-        if (activeCoverAmountDelta.gt(new BN(1e18.toString()))) {
+
+        if (activeCoverAmountDelta.abs().gt(new BN(1e18.toString()))) {
           significantDeltas.push({ ...counts, productName: product.name, productKey, asset });
           // console.log(`Significant different for ${product.name} ${productKey}`);
         }
@@ -144,6 +147,12 @@ async function main () {
   }
   console.log(significantDeltas);
   console.log(`Found significant differences in ${significantDeltas.length} protocol/asset pairs`);
+
+  const negativeDeltas = significantDeltas.filter(delta => delta.activeCoverAmountDelta.lt(0));
+
+  console.log('Negative deltas: ');
+
+  console.log(negativeDeltas);
   return;
 
   const allActiveCovers = await fetchAllActiveCovers({

--- a/scripts/active-cover-processing.js
+++ b/scripts/active-cover-processing.js
@@ -98,7 +98,8 @@ async function main () {
 
   const coverDataLengthAfter = coverAmountTracker.coverData.length;
 
-
+  assert(coverDataLengthAfter === coverDataLengthBefore, 'Length increased (no extra cover expected)');
+  
   // !!!! IMPORTANT: uncomment this so all covers that expired since we eliminated on-chain substraction
   // are counted out.
 
@@ -113,8 +114,6 @@ async function main () {
   //     data.validUntil = data.validUntil.addn(24 * 30 * 3600); // artificially add 1 month
   //   }
   // });
-
-  assert(coverDataLengthAfter === coverDataLengthBefore, 'Length increased (no extra cover expected)');
 
   const active = await coverAmountTracker.getActiveCoverAmount(
     '0x1F98431c8aD98523631AE4a59f267346ea31F984',

--- a/src/app.js
+++ b/src/app.js
@@ -1,19 +1,17 @@
 require('dotenv').config();
-const mongoose = require('mongoose');
 const Web3 = require('web3');
 const QuoteEngine = require('./quote-engine');
 const NexusContractLoader = require('./nexus-contract-loader');
 const routes = require('./routes');
 const log = require('./log');
 const { getEnv } = require('./utils');
-const CoverAmountTracker = require("./cover-amount-tracker");
+const CoverAmountTracker = require('./cover-amount-tracker');
 
 async function initApp () {
   const PROVIDER_URL = getEnv('PROVIDER_URL');
   const VERSION_DATA_URL = getEnv('VERSION_DATA_URL');
   const PRIVATE_KEY = getEnv('PRIVATE_KEY');
   const NETWORK = getEnv('NETWORK', 'mainnet');
-  const MONGO_URL = getEnv('MONGO_URL', 'mainnet');
   const CAPACITY_FACTOR_END_DATE = getEnv('CAPACITY_FACTOR_END_DATE', 'mainnet');
   const QUOTE_SIGN_MIN_INTERVAL_SECONDS = parseInt(getEnv('QUOTE_SIGN_MIN_INTERVAL_SECONDS'));
 
@@ -27,7 +25,7 @@ async function initApp () {
   log.info(`Connecting to node at ${new URL(PROVIDER_URL).origin}..`);
   const web3 = new Web3(PROVIDER_URL);
   await web3.eth.net.isListening();
-  
+
   log.info('Initializing NexusContractLoader..');
   const nexusContractLoader = new NexusContractLoader(NETWORK, VERSION_DATA_URL, web3.eth.currentProvider);
   await nexusContractLoader.init();
@@ -37,7 +35,7 @@ async function initApp () {
   await coverAmountTracker.initialize();
 
   const quoteEngine = new QuoteEngine(
-    nexusContractLoader, PRIVATE_KEY, web3, CAPACITY_FACTOR_END_DATE, QUOTE_SIGN_MIN_INTERVAL_SECONDS, coverAmountTracker
+    nexusContractLoader, PRIVATE_KEY, web3, CAPACITY_FACTOR_END_DATE, QUOTE_SIGN_MIN_INTERVAL_SECONDS, coverAmountTracker,
   );
   const app = routes(quoteEngine);
   return app;

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -4,143 +4,143 @@ const log = require('./log');
 const START_ID = '6820'; // oldest claimable cover id
 
 const CURRENCIES_ADDRESSES = {
-    ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
-    DAI: '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+  ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+  DAI: '0x6B175474E89094C44Da98b954EedeAC495271d0F',
 };
 
 const CoverStatus = {
-    ClaimAccepted: 1
-}
+  ClaimAccepted: 1,
+};
 
 const BATCH_SIZE = 1000;
 
 const MINUTE_IN_MILLIS = 60 * 1000;
 
 function createBatches (a, batchSize) {
-    const batches = [];
-    let currentBatch = [];
-    for (let i = 0; i < a.length; i++) {
-        if (currentBatch.length === batchSize) {
-            batches.push(currentBatch);
-            currentBatch = [a[i]];
-        } else {
-            currentBatch.push(a[i]);
-        }
+  const batches = [];
+  let currentBatch = [];
+  for (let i = 0; i < a.length; i++) {
+    if (currentBatch.length === batchSize) {
+      batches.push(currentBatch);
+      currentBatch = [a[i]];
+    } else {
+      currentBatch.push(a[i]);
     }
-    if (currentBatch.length > 0) {
-        batches.push(currentBatch);
-    }
-    return batches;
+  }
+  if (currentBatch.length > 0) {
+    batches.push(currentBatch);
+  }
+  return batches;
 }
 
 class CoverAmountTracker {
 
-    constructor (nexusContractLoader, web3) {
-        this.nexusContractLoader = nexusContractLoader;
-        this.web3 = web3;
-        this.coverData = [];
+  constructor (nexusContractLoader, web3) {
+    this.nexusContractLoader = nexusContractLoader;
+    this.web3 = web3;
+    this.coverData = [];
+  }
+
+  async initialize () {
+    this.lastVerifiedBlock = (await this.web3.eth.getBlock('latest')).number;
+    this.lastCheckedCoverId = START_ID - 1;
+    await this.fetchAllCovers();
+
+    // timeouts are expressed in milliseconds
+    setInterval(() => this.fetchAllCovers(), MINUTE_IN_MILLIS);
+    setInterval(() => this.fetchPayoutEvents(), MINUTE_IN_MILLIS);
+  }
+
+  async fetchAllCovers (reset) {
+
+    if (reset) {
+      // start with a clean slate
+      log.info(`Clearing existing cover data.`);
+      this.lastCheckedCoverId = START_ID - 1;
+      this.coverData = [];
     }
 
-    async initialize() {
-        this.lastVerifiedBlock = (await this.web3.eth.getBlock('latest')).number;
-        this.lastCheckedCoverId = START_ID - 1;
-        await this.fetchAllCovers();
+    log.info(`Fetching all new covers starting at cover id: ${this.lastCheckedCoverId}`);
+    const quotationData = this.nexusContractLoader.instance('QD');
+    const lastCoverId = (await quotationData.getCoverLength()).toNumber() - 1;
 
-        // timeouts are expressed in milliseconds
-        setInterval(() => this.fetchAllCovers(), MINUTE_IN_MILLIS);
-        setInterval(() => this.fetchPayoutEvents(), MINUTE_IN_MILLIS);
+    const activeCoverIds = [];
+    for (let j = this.lastCheckedCoverId; j <= lastCoverId; j++) {
+      activeCoverIds.push(j);
     }
 
-    async fetchAllCovers (reset) {
+    log.info(`Fetching ${activeCoverIds.length} covers.`);
 
-        if (reset) {
-            // start with a clean slate
-            log.info(`Clearing existing cover data.`);
-            this.lastCheckedCoverId = START_ID - 1;
-            this.coverData = [];
-        }
+    for (const batch of createBatches(activeCoverIds, BATCH_SIZE)) {
+      log.info(`Fetching batch of covers with ids ${batch[0]} - ${batch[batch.length - 1]}`);
+      const coversInBatch = await Promise.all(batch.map(async id => {
+        const coverData = await this.fetchCover(id);
+        return coverData;
+      }));
+      this.coverData.push(...coversInBatch);
+    }
+    this.lastCheckedCoverId = lastCoverId;
+  }
 
-        log.info(`Fetching all new covers starting at cover id: ${this.lastCheckedCoverId}`);
-        const quotationData = this.nexusContractLoader.instance('QD');
-        const lastCoverId = (await quotationData.getCoverLength()).toNumber() - 1;
+  async fetchCover (id) {
+    const gateway = this.nexusContractLoader.instance('GW');
+    const tokenController = this.nexusContractLoader.instance('TC');
+    const coverData = await gateway.getCover(id);
+    const coverInfo = await tokenController.coverInfo(id);
+    return { ...coverData, ...coverInfo };
+  }
 
-        const activeCoverIds = [];
-        for (let j = this.lastCheckedCoverId; j <= lastCoverId; j++) {
-            activeCoverIds.push(j);
-        }
+  async fetchPayoutEvents () {
 
-        log.info(`Fetching ${activeCoverIds.length} covers.`);
+    log.info(`Fetching payout events starting at block: ${this.lastVerifiedBlock}`);
+    const pool = this.nexusContractLoader.instance('P1');
+    const payoutEvents = await pool.getPastEvents('Payout', { fromBlock: this.lastVerifiedBlock });
 
-        for (const batch of createBatches(activeCoverIds, BATCH_SIZE)) {
-            log.info(`Fetching batch of covers with ids ${batch[0]} - ${batch[batch.length - 1]}`);
-            const coversInBatch = await Promise.all(batch.map(async id => {
-                const coverData = await this.fetchCover(id);
-                return coverData;
-            }));
-            this.coverData.push(...coversInBatch);
-        }
-        this.lastCheckedCoverId = lastCoverId;
+    if (payoutEvents.length > 0) {
+      // in case of a single payout event we refetch all cover data (rare event)
+      // the Payout event does not have enough info to refresh only 1 particular cover
+
+      log.info(`Payout events detected: ${payoutEvents.length}`);
+      await this.fetchAllCovers(true);
     }
 
-    async fetchCover (id) {
-        const gateway = this.nexusContractLoader.instance('GW');
-        const tokenController = this.nexusContractLoader.instance('TC');
-        const coverData = await gateway.getCover(id);
-        const coverInfo = await tokenController.coverInfo(id);
-        return { ...coverData, ...coverInfo };
+    this.lastVerifiedBlock = (await this.web3.eth.getBlock('latest')).number;
+    log.info(`Last verified block is now: ${this.lastVerifiedBlock}`);
+  }
+
+  getActiveCoverAmount (contract, currency) {
+
+    const currencyAddress = CURRENCIES_ADDRESSES[currency];
+
+    // now is expressed in seconds to be compared to cover.validUntil
+    const now = new Date().getTime() / 1000;
+
+    const contractCovers = this.coverData.filter(
+      c => {
+        return c.contractAddress === contract &&
+                c.coverAsset === currencyAddress &&
+                c.validUntil.toNumber() > now;
+      },
+    );
+    return this.computeActiveCoverAmount(contractCovers);
+  }
+
+  computeActiveCoverAmount (covers) {
+    let activeCoverSum = new BN(0);
+
+    // TODO: remove console.log
+    console.log(`Computing based on ${covers.length} covers`);
+    for (const cover of covers) {
+      if (cover.status.toNumber() !== CoverStatus.ClaimAccepted) {
+        // not claimed successfully and not expired
+        // partial claims are counted as full claims for the purpose of the total sum assured computation
+        // Partial claims can only be done once - cover is invalid after.
+        activeCoverSum = activeCoverSum.add(cover.sumAssured);
+      }
     }
+    return activeCoverSum;
+  }
 
-    async fetchPayoutEvents () {
-
-        log.info(`Fetching payout events starting at block: ${this.lastVerifiedBlock}`);
-        const pool = this.nexusContractLoader.instance('P1');
-        const payoutEvents = await pool.getPastEvents('Payout', { fromBlock: this.lastVerifiedBlock });
-
-        if (payoutEvents.length > 0) {
-            // in case of a single payout event we refetch all cover data (rare event)
-            // the Payout event does not have enough info to refresh only 1 particular cover
-
-            log.info(`Payout events detected: ${payoutEvents.length}`);
-            await this.fetchAllCovers(true);
-        }
-
-        this.lastVerifiedBlock = (await this.web3.eth.getBlock('latest')).number;
-        log.info(`Last verified block is now: ${this.lastVerifiedBlock}`);
-    }
-
-    getActiveCoverAmount (contract, currency) {
-
-        const currencyAddress = CURRENCIES_ADDRESSES[currency];
-
-        // now is expressed in seconds to be compared to cover.validUntil
-        const now = new Date().getTime() / 1000;
-
-        const contractCovers = this.coverData.filter(
-            c => {
-                return c.contractAddress === contract
-                && c.coverAsset === currencyAddress
-                && c.validUntil.toNumber() > now;
-            }
-        );
-        return this.computeActiveCoverAmount(contractCovers);
-    }
-
-    computeActiveCoverAmount(covers) {
-        let activeCoverSum = new BN(0);
-
-        // TODO: remove console.log
-        console.log(`Computing based on ${covers.length} covers`);
-        for (const cover of covers) {
-            if (cover.status.toNumber() !== CoverStatus.ClaimAccepted) {
-                // not claimed successfully and not expired
-                // partial claims are counted as full claims for the purpose of the total sum assured computation
-                // Partial claims can only be done once - cover is invalid after.
-                activeCoverSum = activeCoverSum.add(cover.sumAssured);
-            }
-        }
-        return activeCoverSum;
-    }
-
-};
+}
 
 module.exports = CoverAmountTracker;

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -65,7 +65,7 @@ class CoverAmountTracker {
     const lastCoverId = (await quotationData.getCoverLength()).toNumber() - 1;
 
     const activeCoverIds = [];
-    for (let j = this.lastCheckedCoverId; j <= lastCoverId; j++) {
+    for (let j = this.lastCheckedCoverId + 1; j <= lastCoverId; j++) {
       activeCoverIds.push(j);
     }
 

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -115,16 +115,10 @@ class CoverAmountTracker {
 
         console.log(`Computing based on ${covers.length} covers`);
         for (const cover of covers) {
-            if (cover.status.toNumber() === CoverStatus.ClaimAccepted) {
-
-                if (cover.requestedPayoutAmount.gtn(0)) {
-
-                    // TODO: revise if this is actually needed or should be 0ed out
-                    activeCoverSum = activeCoverSum.add(cover.sumAssured).sub(cover.requestedPayoutAmount);
-                }
-
-            } else {
-                // not claimed and not expired
+            if (cover.status.toNumber() !== CoverStatus.ClaimAccepted) {
+                // not claimed successfully and not expired
+                // partial claims are counted as full claims for the purpose of the total sum assured computation
+                // Partial claims can only be done once - cover is invalid after.
                 activeCoverSum = activeCoverSum.add(cover.sumAssured);
             }
         }

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -1,7 +1,7 @@
 const BN = require('bn.js');
 const log = require('./log');
 
-const START_ID = '6820'; // oldest claimable cover id
+const START_ID = '6000'; // capture all claimable covers
 
 const CURRENCIES_ADDRESSES = {
   ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -128,6 +128,7 @@ class CoverAmountTracker {
     computeActiveCoverAmount(covers) {
         let activeCoverSum = new BN(0);
 
+        // TODO: remove console.log
         console.log(`Computing based on ${covers.length} covers`);
         for (const cover of covers) {
             if (cover.status.toNumber() !== CoverStatus.ClaimAccepted) {

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -74,7 +74,6 @@ class CoverAmountTracker {
             this.coverData.push(...coversInBatch);
         }
         this.lastCheckedCoverId = lastCoverId;
-        // this.coverData.push(...coverData);
     }
 
     async fetchCover (id) {
@@ -116,8 +115,14 @@ class CoverAmountTracker {
 
         console.log(`Computing based on ${covers.length} covers`);
         for (const cover of covers) {
-            if (cover.status.toNumber() === CoverStatus.ClaimAccepted && cover.requestedPayoutAmount.gtn(0)) {
-                activeCoverSum = activeCoverSum.add(cover.sumAssured).sub(cover.requestedPayoutAmount);
+            if (cover.status.toNumber() === CoverStatus.ClaimAccepted) {
+
+                if (cover.requestedPayoutAmount.gtn(0)) {
+
+                    // TODO: revise if this is actually needed or should be 0ed out
+                    activeCoverSum = activeCoverSum.add(cover.sumAssured).sub(cover.requestedPayoutAmount);
+                }
+
             } else {
                 // not claimed and not expired
                 activeCoverSum = activeCoverSum.add(cover.sumAssured);

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -95,6 +95,7 @@ class CoverAmountTracker {
 
         if (payoutEvents.length > 0) {
             // in case of a single payout event we refetch all cover data (rare event)
+            // the Payout event does not have enough info to refresh only 1 particular cover
             await this.fetchAllCovers(true);
         }
 

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -55,6 +55,7 @@ class CoverAmountTracker {
 
         if (reset) {
             // start with a clean slate
+            log.info(`Clearing existing cover data.`);
             this.lastCheckedCoverId = START_ID - 1;
             this.coverData = [];
         }
@@ -90,16 +91,21 @@ class CoverAmountTracker {
     }
 
     async fetchPayoutEvents () {
+
+        log.info(`Fetching payout events starting at block: ${this.lastVerifiedBlock}`);
         const pool = this.nexusContractLoader.instance('P1');
         const payoutEvents = await pool.getPastEvents('Payout', { fromBlock: this.lastVerifiedBlock });
 
         if (payoutEvents.length > 0) {
             // in case of a single payout event we refetch all cover data (rare event)
             // the Payout event does not have enough info to refresh only 1 particular cover
+
+            log.info(`Payout events detected: ${payoutEvents.length}`);
             await this.fetchAllCovers(true);
         }
 
         this.lastVerifiedBlock = (await this.web3.eth.getBlock('latest')).number;
+        log.info(`Last verified block is now: ${this.lastVerifiedBlock}`);
     }
 
     getActiveCoverAmount (contract, currency) {

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -1,0 +1,70 @@
+
+
+
+const START_ID = 'x'; // oldest claimable cover id
+
+const coverAmountTracker = (nexusContractLoader, web3) => {
+    // data store
+    // mapping contract address => { eth: m, dai: n }
+    const amounts = {};
+    // array of { id, contract, currency: ETH|DAI, amount: n, expiration: d, claimed: true|false, processed: true|false }
+    const covers = {};
+
+    const lastCoverId = START_ID - 1;
+    const lastClaimPayoutBlockNumber = 0;
+
+    const fetchCover = async id => {
+        // query QD & TC
+        // construct object:
+        // return { id, contract, currency, amount, expiration, claimed, processed }
+    }
+
+    const fetchNewCovers = async () => {
+        // get last cover id in prod
+        // if last cover id in prod > lastCoverId
+        // for i = lastCoverId + 1; i <= lastCoverIdInProd
+        //   - fetchCover(id)
+        //   - if cover is past expiration date set processed = true
+        //   - if cover has accepted claim skip set processed = true
+        //   - if not processed: amounts[contract][currency] += amount
+        //   - add to covers object
+        //   - lastCoverId = i
+    }
+
+    const fetchPayoutEvents = async lastBlock => {
+        const fromBlock = lastClaimPayoutBlockNumber + 1;
+        // get events in batches of 1000 blocks
+        // for each payout
+        //   - get claim id
+        //   - get cover id
+        //   - set covers[coverId].claimed = true
+        //   - if not covers[coverId].processed
+        //      - reduce total cover amount
+        //      - set covers[coverId].processed = true
+        // lastClaimPayoutBlockNumber = lastBlockNumber
+    }
+
+    const expireCovers = () => {
+        // for loop through all Object.keys(covers)
+        // if expiration date is in the past and not processed:
+        //   - amounts[contract][currency] -= amount
+        //   - set covers[coverId].processed = true
+    }
+
+    // initialization:
+    await fetchNewCovers();
+    setInterval(300, fetchNewCovers);
+
+    await fetchPayoutEvents();
+    setInterval(300, fetchPayoutEvents);
+
+    setInterval(60, expireCovers);
+
+    const api = {
+        get: (contract, currency) => amounts[contract][currency],
+    };
+
+    return api;
+};
+
+module.exports = coverAmountTracker;

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -1,8 +1,15 @@
 const fetch = require("node-fetch");
+const BN = require('bn.js');
 
 const START_ID = 'x'; // oldest claimable cover id
 
+const CURRENCIES_ADDRESSES = {
+    ETH: '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE',
+    DAI: '0x6B175474E89094C44Da98b954EedeAC495271d0F'
+};
+
 class coverAmountTracker {
+
 
 
     constructor (nexusContractLoader, web3) {
@@ -12,6 +19,7 @@ class coverAmountTracker {
     }
 
     async initialize() {
+        this.lastCoverBlock = (await this.web3.eth.getBlock('latest')).number;
         this.coverData = this.fetchAllActiveCovers();
     }
 
@@ -59,18 +67,13 @@ class coverAmountTracker {
         return { ...coverData, ...coverInfo };
     }
 
-    const fetchNewCovers = async () => {
-        // get last cover id in prod
-        // if last cover id in prod > lastCoverId
-        // for i = lastCoverId + 1; i <= lastCoverIdInProd
-        //   - fetchCover(id)
-        //   - if cover is past expiration date set processed = true
-        //   - if cover has accepted claim skip set processed = true
-        //   - if not processed: amounts[contract][currency] += amount
-        //   - add to covers object
-        //   - lastCoverId = i
-
+    async fetchNewCovers {
         const coverDetailsEvents = await this.quotationData.getPastEvents('CoverDetailsEvent', { fromBlock: lastCoverBlock });
+        for (const event of coverDetailsEvents) {
+            const newCoverData = await this.fetchCover(event.cid);
+            this.coverData.push(newCoverData);
+        }
+        this.lastCoverBlock = (await this.web3.eth.getBlock('latest')).number;
     }
 
     const fetchPayoutEvents = async lastBlock => {
@@ -86,13 +89,6 @@ class coverAmountTracker {
         // lastClaimPayoutBlockNumber = lastBlockNumber
     }
 
-    const expireCovers = () => {
-        // for loop through all Object.keys(covers)
-        // if expiration date is in the past and not processed:
-        //   - amounts[contract][currency] -= amount
-        //   - set covers[coverId].processed = true
-    }
-
     // // initialization:
     // await fetchNewCovers();
     // setInterval(300, fetchNewCovers);
@@ -102,8 +98,21 @@ class coverAmountTracker {
     //
     // setInterval(60, expireCovers);
 
-    getActiveCoverAmount(contract, currency) {
+    getActiveCoverAmount (contract, currency) {
 
+        const currencyAddress = CURRENCIES_ADDRESSES;
+        const contractCovers = this.coverData.filter(
+            c => c.contractAddress === contract && c.coverAsset === currencyAddress
+        );
+        contractCovers
+    }
+
+    computeActiveCoverAmount(covers) {
+        let activeCoverSum = new BN(0);
+
+        for (const cover of covers) {
+
+        }
     }
 
 };

--- a/src/cover-amount-tracker.js
+++ b/src/cover-amount-tracker.js
@@ -55,7 +55,7 @@ class CoverAmountTracker {
 
         console.log(`Fetching all new covers starting at cover id: ${this.lastCheckedCoverId}`);
         const quotationData = this.nexusContractLoader.instance('QD');
-        const lastCoverId = this.lastCheckedCoverId + 2; // (await quotationData.getCoverLength()).toNumber() - 1;
+        const lastCoverId = (await quotationData.getCoverLength()).toNumber() - 1;
 
         const activeCoverIds = [];
         for (let j = this.lastCheckedCoverId; j <= lastCoverId; j++) {
@@ -99,11 +99,8 @@ class CoverAmountTracker {
 
         const currencyAddress = CURRENCIES_ADDRESSES[currency];
 
-        const now = new Date().getTime();
-        console.log({
-            contract,
-            currencyAddress
-        })
+        const now = new Date().getTime() / 1000;
+
         const contractCovers = this.coverData.filter(
             c => {
                 return c.contractAddress === contract
@@ -116,6 +113,8 @@ class CoverAmountTracker {
 
     computeActiveCoverAmount(covers) {
         let activeCoverSum = new BN(0);
+
+        console.log(`Computing based on ${covers.length} covers`);
         for (const cover of covers) {
             if (cover.status.toNumber() === CoverStatus.ClaimAccepted && cover.requestedPayoutAmount.gtn(0)) {
                 activeCoverSum = activeCoverSum.add(cover.sumAssured).sub(cover.requestedPayoutAmount);

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,6 @@ async function init () {
 
 init()
   .catch(error => {
-    log.error(`Unhandled app error: ${error}`);
+    log.error(`Unhandled app error: ${error.stack}`);
     process.exit(1);
   });

--- a/src/quote-engine.js
+++ b/src/quote-engine.js
@@ -38,14 +38,22 @@ class QuoteEngine {
    * @param {Web3} web3
    * @param {string} capacityFactorEndDate
    * @param {number} quoteSignMinInterval
+   * @param {CoverAmountTracker} coverAmountTracker
    */
-  constructor (nexusContractLoader, privateKey, web3, capacityFactorEndDate, quoteSignMinInterval) {
+  constructor (
+      nexusContractLoader,
+      privateKey,
+      web3,
+      capacityFactorEndDate,
+      quoteSignMinInterval,
+      coverAmountTracker
+  ) {
     this.nexusContractLoader = nexusContractLoader;
     this.privateKey = privateKey;
     this.web3 = web3;
     this.pooledStaking = this.nexusContractLoader.instance('PS');
 
-    this.coverAmountTracker = coverAmountTracker(nexusContractLoader, web3);
+    this.coverAmountTracker = coverAmountTracker;
 
     const format = 'MM/DD/YYYY';
     const endMoment = moment(capacityFactorEndDate, format, true);
@@ -226,7 +234,8 @@ class QuoteEngine {
     for (const contractAddress of contractAddressesLowerCased) {
       const amounts = await Promise.all(
         CURRENCIES.map(async (currency) => {
-          const sumAssured = this.coverAmountTracker.get(contractAddress, currency);
+
+          const sumAssured = this.coverAmountTracker.getActiveCoverAmount(contractAddress, currency);
           return {
             sumAssured: toDecimal(sumAssured),
             contractAddress,


### PR DESCRIPTION
TODO: remove the scripts/active-cover-processing.js

I checked it in for demonstrative purposes to show how things were tested.



## Testing

Manual testing using the file in /scripts.

## Report on comparison with production values.

There are 22 protocol/asset pairs where active cover amount is different for on-chain.

On-chain is out of date. This is done as a sanity check.

To obtain this list, run 

```node scripts/active-cover-processing.js```


